### PR TITLE
Return 'Unit' on methods with side-effects

### DIFF
--- a/src/main/scala/me/archdev/restapi/utils/FlywayService.scala
+++ b/src/main/scala/me/archdev/restapi/utils/FlywayService.scala
@@ -4,17 +4,10 @@ import org.flywaydb.core.Flyway
 
 class FlywayService(jdbcUrl: String, dbUser: String, dbPassword: String) {
 
-  private val flyway = new Flyway()
+  private[this] val flyway = new Flyway()
   flyway.setDataSource(jdbcUrl, dbUser, dbPassword)
 
-  def migrateDatabaseSchema = {
-    flyway.migrate()
-    this
-  }
+  def migrateDatabaseSchema() : Unit = flyway.migrate()
 
-  def dropDatabase = {
-    flyway.clean()
-    this
-  }
-
+  def dropDatabase() : Unit = flyway.clean()
 }

--- a/src/test/scala/me/archdev/utils/InMemoryPostgresStorage.scala
+++ b/src/test/scala/me/archdev/utils/InMemoryPostgresStorage.scala
@@ -25,7 +25,8 @@ object InMemoryPostgresStorage {
     val flywayService = new FlywayService(jdbcUrl, dbUser, dbPassword)
 
     val process = psqlInstance.prepare(psqlConfig).start()
-    flywayService.dropDatabase.migrateDatabaseSchema
+    flywayService.dropDatabase()
+    flywayService.migrateDatabaseSchema()
     process
   }
 }


### PR DESCRIPTION
- Methods with side-effects should return 'Unit'. Adding a '()' also indicates the method is not idempotent.

Ref: https://books.google.es/books?id=AnurBQAAQBAJ&pg=PA23&lpg=PA23&dq=Unit+side+effects+scala&source=bl&ots=7KbBk9r94Z&sig=-2c1a64SCblWOKoy4sqxLdad2_E&hl=es&sa=X&ved=0ahUKEwjJ4LvK99nPAhUH7RQKHfB8Dt0Q6AEIXDAI#v=onepage&q=Unit%20side%20effects%20scala&f=false
